### PR TITLE
Add method to online_calculator for registering leaf nodes

### DIFF
--- a/include/sts/likelihood/detail/online_calculator.hpp
+++ b/include/sts/likelihood/detail/online_calculator.hpp
@@ -90,6 +90,19 @@ void online_calculator::register_node( sts::particle::node n )
     node_buffer_map[n.get()] = get_id();
 }
 
+/// Register a leaf node with the calculator
+
+/// \param n Node
+/// \param taxon The taxon name for a node. Must match one of the input taxa passed to
+///              sts::likelihood::online_calculator::initialize.
+void online_calculator::register_leaf(sts::particle::node n, const std::string taxon)
+{
+    assert(node_buffer_map.count(n.get()) == 0);
+    assert(taxon_buffer_map.count(taxon) == 1);
+    assert(n->is_leaf());
+    node_buffer_map[n.get()] = taxon_buffer_map[taxon];
+}
+
 int online_calculator::get_buffer( sts::particle::node n )
 {
     if(node_buffer_map.count(n.get()) == 0) register_node(n);
@@ -103,7 +116,6 @@ void online_calculator::unregister_node( const sts::particle::phylo_node* n )
     node_buffer_map.erase(n);
     node_ll_map.erase(n);
 }
-
 
 ///Initialize an instance of the BEAGLE library with partials coming from sequences.
 ///  \param sites The sites
@@ -127,8 +139,9 @@ void online_calculator::initialize(std::shared_ptr<bpp::SiteContainer> sites, st
     for(int i = 0; i < n_seqs; i++) {
         std::vector<double> seq_partials = get_partials(sites->getSequence(i), *model, sites->getAlphabet());
         beagleSetPartials(instance, i, seq_partials.data());
+        taxon_buffer_map[sites->getSequencesNames()[i]] = i;
     }
-    next_id = 0;
+    next_id = n_seqs;
 
     set_eigen_and_rates_and_weights(instance);
 

--- a/include/sts/likelihood/detail/online_calculator_fwd.hpp
+++ b/include/sts/likelihood/detail/online_calculator_fwd.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <stack>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -35,6 +36,7 @@ public:
     void free_id(int id);
     double calculate_ll(std::shared_ptr<sts::particle::phylo_node> node, std::unordered_set<std::shared_ptr<sts::particle::phylo_node>>& visited);
     void register_node(std::shared_ptr< sts::particle::phylo_node > n);
+    void register_leaf(std::shared_ptr< sts::particle::phylo_node > n, const std::string taxon);
     void unregister_node(const sts::particle::phylo_node* n);
     bool initialized;
 
@@ -48,6 +50,7 @@ private:
     std::stack<int> free_ids;
     std::unordered_map<const sts::particle::phylo_node*, double> node_ll_map; // caches the root ll at each node
     std::unordered_map<const sts::particle::phylo_node*, int> node_buffer_map; // maps nodes to a beagle buffer ID
+    std::unordered_map<std::string, int> taxon_buffer_map; // maps taxon names to beagle buffer id.
 
     int create_beagle_instance();
     void grow();

--- a/src/sts.cc
+++ b/src/sts.cc
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
     unordered_map<node, string> name_map;
     for(int i = 0; i < num_iters; i++) {
         leaf_nodes[i] = make_shared<phylo_node>(calc);
-        calc->register_node(leaf_nodes[i]);
+        calc->register_leaf(leaf_nodes[i], aln->getSequencesNames()[i]);
         name_map[leaf_nodes[i]] = aln->getSequencesNames()[i];
     }
     forest_likelihood fl(calc, leaf_nodes);


### PR DESCRIPTION
Right now for a sequence to be associated with its likelihood vectors, the first `phylo_nodes` registered must be the leaves, in the same order that they appear in the alignment.

For testing, it would be useful to be able to explicitly declare a `phylo_node` to be associated with a sequence.
