### PR TITLE
Periodic recomputation of cached lnL?

### DIFF
--- a/include/sts/likelihood/detail/online_calculator.hpp
+++ b/include/sts/likelihood/detail/online_calculator.hpp
@@ -144,8 +144,6 @@ void online_calculator::initialize(std::shared_ptr<bpp::SiteContainer> sites, st
     next_id = n_seqs;
 
     set_eigen_and_rates_and_weights(instance);
-
-    initialized = true;
 }
 
 
@@ -270,7 +268,7 @@ double online_calculator::calculate_ll(sts::particle::node node, std::unordered_
     }
 
     // If we have a cached root LL for this node just return that instead of recalculating.
-    if(node_ll_map.count(node.get()) != 0) {
+    if(!verify_cached_ll && node_ll_map.count(node.get()) != 0) {
         return node_ll_map[node.get()];
     }
 
@@ -318,6 +316,10 @@ double online_calculator::calculate_ll(sts::particle::node node, std::unordered_
                  cumulativeScalingIndices,               // cumulative scaling index
                  1,                                      // count
                  &logL);                                 // OUT: log likelihood
+
+    // Verify LL if requested.
+    if(verify_cached_ll && node_ll_map.count(node.get()))
+        assert(std::abs(node_ll_map[node.get()] - logL) < 1e-5);
 
     node_ll_map[node.get()] = logL; // Record the log likelihood for later use.
     return logL;

--- a/include/sts/likelihood/detail/online_calculator_fwd.hpp
+++ b/include/sts/likelihood/detail/online_calculator_fwd.hpp
@@ -30,7 +30,7 @@ namespace likelihood
 class online_calculator
 {
 public:
-    online_calculator() : initialized(false), instance(-1), next_id(0)  {};
+    online_calculator() : verify_cached_ll(false), instance(-1), next_id(0) {};
     ~online_calculator();
     void initialize(std::shared_ptr<bpp::SiteContainer>, std::shared_ptr<bpp::SubstitutionModel>);
     int get_id();
@@ -40,10 +40,13 @@ public:
     void register_node(std::shared_ptr< sts::particle::phylo_node > n);
     void register_leaf(std::shared_ptr< sts::particle::phylo_node > n, const std::string taxon);
     void unregister_node(const sts::particle::phylo_node* n);
-    bool initialized;
 
     void set_weights(std::vector<double> weights);
 
+    /// If \c true, unconditionally recomputes the log likelihood of \c node.
+    /// If the log-likelihood of \c node has previously been calculated, verifies that the new value matches the cached
+    /// value.
+    bool verify_cached_ll;
 private:
     BeagleInstanceDetails instance_details;
     std::shared_ptr<bpp::SiteContainer> sites;

--- a/src/sts.cc
+++ b/src/sts.cc
@@ -1,14 +1,12 @@
-#include "sts/likelihood.hpp"
-#include "sts/moves.hpp"
-#include "sts/particle.hpp"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <sstream>
 #include <fstream>
-#include <stack>
 #include <memory>
+#include <sstream>
+#include <stack>
 #include <unordered_map>
+
 #include <Bpp/Phyl/Model/GTR.h>
 #include <Bpp/Phyl/Model/HKY85.h>
 #include <Bpp/Phyl/Model/JCnuc.h>
@@ -18,7 +16,12 @@
 #include <Bpp/Seq/Alphabet/DNA.h>
 #include <Bpp/Seq/Alphabet/ProteicAlphabet.h>
 #include <Bpp/Seq/Container/SiteContainer.h>
+
 #include "tclap/CmdLine.h"
+
+#include "sts/likelihood.hpp"
+#include "sts/moves.hpp"
+#include "sts/particle.hpp"
 
 #define _STRINGIFY(s) #s
 #define STRINGIFY(s) _STRINGIFY(s)
@@ -101,6 +104,7 @@ int main(int argc, char** argv)
     TCLAP::ValuesConstraint<string> allowed_bl_dens(all_bl_dens);
     TCLAP::ValueArg<string> bl_dens(
         "", "bl-dens", "Branch length prior & proposal density", false, "expon", &allowed_bl_dens, cmd);
+    TCLAP::SwitchArg verify_ll("", "verify-cached-ll", "Verify cached log-likelihoods", cmd, false);
 
     try {
         cmd.parse(argc, argv);
@@ -134,6 +138,7 @@ int main(int argc, char** argv)
     vector<node> leaf_nodes;
 
     shared_ptr<online_calculator> calc = make_shared<online_calculator>();
+    calc->verify_cached_ll = verify_ll.getValue();
     calc->initialize(aln, model);
     if(!no_compress.getValue())
         calc->set_weights(compressed_site_weights(*input_alignment, *aln));


### PR DESCRIPTION
Every X generations the calculator could ignore its LL cache and recompute values at each node to verify that they match what is stored in the cache. If they don't match than an assert fails or an error is thrown. 
