### PR TITLE
eliminate tree height

### DIFF
--- a/include/sts/moves/rooted_merge.hpp
+++ b/include/sts/moves/rooted_merge.hpp
@@ -89,7 +89,6 @@ int rooted_merge::do_move(long time, smc::particle<particle::particle>& p_from, 
     // worry about is the branch length d.
     // This is returned from the proposal function.
     bl_proposal(*part, rng);
-    pp->node->calc_height();
 
     // We want to have:
     // w_r(s_r) = \frac{\gamma^*_r(s_r)}{\gamma^*_{r-1}(s_{r-1})} \frac{1}{\nu^+(s_{r-1} \rightarrow s_r)} (*).

--- a/include/sts/particle/detail/phylo_node.hpp
+++ b/include/sts/particle/detail/phylo_node.hpp
@@ -53,14 +53,6 @@ bool phylo_node::is_leaf() const
     return this->child1 == NULL && this->child2 == NULL;
 }
 
-void phylo_node::calc_height()
-{
-    if(is_leaf())
-        this->height = 0.0;
-    else
-        this->height = std::max(child1->node->height + 2 * child1->length, child2->node->height + 2 * child2->length);
-}
-
 node phylo_node::of_tree(std::shared_ptr<likelihood::online_calculator> calc, bpp::TreeTemplate<bpp::Node> &tree, int node_number, std::unordered_map<node, std::string>& names)
 {
     node n = std::make_shared<phylo_node>(calc);

--- a/include/sts/particle/detail/phylo_node_fwd.hpp
+++ b/include/sts/particle/detail/phylo_node_fwd.hpp
@@ -39,13 +39,7 @@ public:
     std::shared_ptr<edge> child1;
     std::shared_ptr<edge> child2;
 
-    // convenience for proposals, height must always increase.
-    // In the non-clock case, height is the diameter (2 * distance to closest leaf)
-    double height;
     bool is_leaf() const;
-
-    /// Calculate the height once children have been set
-    void calc_height();
 
     /// Make a phylo_node from a bpp Tree
     static std::shared_ptr<phylo_node>


### PR DESCRIPTION
With the advent of backwards proposal densities, we no longer need to keep track of tree height, do we?
